### PR TITLE
Edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/LNP-BP/rust-amplify"
 homepage = "https://github.com/LNP-BP"
 license = "MIT"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 exclude = [
     ".github",
     "derive",

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,6 +1,4 @@
 #[macro_use]
-extern crate criterion;
-
 use criterion::{black_box, Criterion};
 
 use amplify_num::u1024;
@@ -35,35 +33,27 @@ fn criterion_posit32(c: &mut Criterion) {
     let x = Posit32::from(12.5);
     let y = Posit32::from(117.334);
 
-    c.bench_function("posit32_add", move |c| {
-        c.iter(|| black_box(x) + black_box(y))
-    });
-    c.bench_function("posit32_sub", move |c| {
-        c.iter(|| black_box(x) - black_box(y))
-    });
-    c.bench_function("posit32_mul", move |c| {
-        c.iter(|| black_box(x) * black_box(y))
-    });
-    c.bench_function("posit32_div", move |c| {
-        c.iter(|| black_box(x) / black_box(y))
-    });
+    c.bench_function("posit32_add", |c| c.iter(|| black_box(&x) + black_box(&y)));
+    c.bench_function("posit32_sub", |c| c.iter(|| black_box(&x) - black_box(&y)));
+    c.bench_function("posit32_mul", |c| c.iter(|| black_box(&x) * black_box(&y)));
+    c.bench_function("posit32_div", |c| c.iter(|| black_box(&x) / black_box(&y)));
 }
 
 fn criterion_softposit32(c: &mut Criterion) {
     let x = P32::from(12.5);
     let y = P32::from(117.334);
 
-    c.bench_function("softposit32_add", move |c| {
-        c.iter(|| black_box(x) + black_box(y))
+    c.bench_function("softposit32_add", |c| {
+        c.iter(|| black_box(&x) + black_box(&y))
     });
-    c.bench_function("softposit32_sub", move |c| {
-        c.iter(|| black_box(x) - black_box(y))
+    c.bench_function("softposit32_sub", |c| {
+        c.iter(|| black_box(&x) - black_box(&y))
     });
-    c.bench_function("softposit32_mul", move |c| {
-        c.iter(|| black_box(x) * black_box(y))
+    c.bench_function("softposit32_mul", |c| {
+        c.iter(|| black_box(&x) * black_box(&y))
     });
-    c.bench_function("softposit32_div", move |c| {
-        c.iter(|| black_box(x) / black_box(y))
+    c.bench_function("softposit32_div", |c| {
+        c.iter(|| black_box(&x) / black_box(&y))
     });
 }
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -2,18 +2,18 @@
 name = "amplify_derive"
 version = "2.11.2"
 description = "Amplifying Rust language capabilities: derive macros for the 'amplify' library"
-authors = ["Dr. Maxim Orlovsky <orlovsky@pandoracore.com>", "Elichai Turkel <elichai.turkel@gmail.com>"]
+authors = [
+    "Dr. Maxim Orlovsky <orlovsky@pandoracore.com>",
+    "Elichai Turkel <elichai.turkel@gmail.com>",
+]
 keywords = ["generics", "derive", "wrap", "patterns"]
 categories = ["data-structures", "rust-patterns"]
 repository = "https://github.com/LNP-BP/rust-amplify"
 homepage = "https://github.com/LNP-BP"
 license = "MIT"
 readme = "README.md"
-edition = "2018"
-include = [
-    "**/*.rs",
-    "Cargo.toml",
-]
+edition = "2021"
+include = ["**/*.rs", "Cargo.toml"]
 
 [lib]
 proc-macro = true

--- a/derive/src/getters.rs
+++ b/derive/src/getters.rs
@@ -386,7 +386,7 @@ fn derive_field_methods(
             #fn_doc
             #[inline]
             pub fn #fn_name(&#mut_prefix self) -> #ret_prefix #ty {
-                #ret_prefix self.#field_name#ret_suffix
+                #ret_prefix self.#field_name #ret_suffix
             }
         })
     }

--- a/num/Cargo.toml
+++ b/num/Cargo.toml
@@ -9,12 +9,14 @@ repository = "https://github.com/LNP-BP/rust-amplify"
 homepage = "https://github.com/LNP-BP"
 license = "MIT"
 readme = "../README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 # This strange naming is a workaround for not being able to define required features for a dependency
 # See https://github.com/rust-lang/api-guidelines/issues/180 for the explanation and references.
-serde_crate = { package = "serde", version = "1.0", features = ["derive"], optional = true }
+serde_crate = { package = "serde", version = "1.0", features = [
+    "derive",
+], optional = true }
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/serde_str_helpers/Cargo.toml
+++ b/serde_str_helpers/Cargo.toml
@@ -2,7 +2,7 @@
 name = "serde_str_helpers"
 version = "0.1.2"
 authors = ["Martin Habovstiak <martin.habovstiak@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "Helpers for using serde with strings"
 keywords = ["serde", "deserialization", "zero-copy", "patterns"]
 categories = ["data-structures", "rust-patterns", "no-std"]

--- a/stringly_conversions/Cargo.toml
+++ b/stringly_conversions/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/LNP-BP/rust-amplify"
 homepage = "https://github.com/LNP-BP"
 license = "MIT"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [features]
 alloc = []

--- a/syn/Cargo.toml
+++ b/syn/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/LNP-BP/rust-amplify"
 homepage = "https://github.com/LNP-BP"
 license = "MIT"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 syn = "1"


### PR DESCRIPTION
Due to [this error](https://github.com/rust-amplify/rust-amplify/actions/runs/3190687266/jobs/5206524255#step:5:63) in CI, I've updated the crates to edition 2021 using [these instructions](https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html).